### PR TITLE
Fix IllegalArgumentException caused by LaunchClassLoader's modification to CodeSource.

### DIFF
--- a/src/main/java/ofdev/launchwrapper/OptifineDevTweakerWrapper.java
+++ b/src/main/java/ofdev/launchwrapper/OptifineDevTweakerWrapper.java
@@ -22,8 +22,13 @@ import java.util.Set;
 public class OptifineDevTweakerWrapper implements ITweaker {
 
     // this requires the jar to be loaded by FML before OptiFine, the easiest way to do it is to name it aa_SomeJar
-    public static final Class<?> OF_TRANSFORMER_LAUNCH_CLASSLOADER = UtilsLW.loadClassLW("optifine.OptiFineClassTransformer");
+    public static final Class<?> OF_TRANSFORMER_LAUNCH_CLASSLOADER;
     public static Path CLASS_DUMP_LOCATION;
+
+    static {
+        Launch.classLoader.addTransformerExclusion("optifine.");
+        OF_TRANSFORMER_LAUNCH_CLASSLOADER = UtilsLW.loadClassLW("optifine.OptiFineClassTransformer");
+    }
 
     @Override public void acceptOptions(List<String> args, File gameDir, File assetsDir, String profile) {
         try {
@@ -49,13 +54,6 @@ public class OptifineDevTweakerWrapper implements ITweaker {
         List<IClassTransformer> transformers =
                 UtilsLW.getFieldValue(LaunchClassLoader.class, Launch.classLoader, "transformers");
         transformers.removeIf(t -> t.getClass().getName().equals("optifine.OptiFineClassTransformer"));
-        // also remove all the new exclusions
-        Set<String> classLoaderExceptions =
-                UtilsLW.getFieldValue(LaunchClassLoader.class, Launch.classLoader, "classLoaderExceptions");
-        classLoaderExceptions.removeIf(t -> t.startsWith("optifine"));
-        Set<String> transformerExceptions =
-                UtilsLW.getFieldValue(LaunchClassLoader.class, Launch.classLoader, "transformerExceptions");
-        transformerExceptions.removeIf(t -> t.startsWith("optifine"));
 
         // OptiFine tweaker constructed new instance of optifine transformer, so it changed it's instance field
         // now that OptiFine tweaker setup is done,fix it


### PR DESCRIPTION
@Barteks2x  I used this mod in dev environment by it didn't work well for me:
```
[13:23:31] [main/INFO] [LaunchWrapper]: Calling tweak class ofdev.launchwrapper.OptifineDevTweakerWrapper
[13:23:39] [main/INFO] [STDOUT]: [optifine.OptiFineClassTransformer:dbg:242]: OptiFine ClassTransformer
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: java.lang.IllegalArgumentException: URI is not hierarchical
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at java.io.File.<init>(File.java:418)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at optifine.OptiFineClassTransformer.<init>(OptiFineClassTransformer.java:43)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at java.lang.Class.newInstance(Class.java:442)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at ofdev.launchwrapper.OptifineDevTransformerWrapper.<init>(OptifineDevTransformerWrapper.java:74)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at java.lang.Class.newInstance(Class.java:442)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at net.minecraft.launchwrapper.LaunchClassLoader.registerTransformer(LaunchClassLoader.java:88)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at ofdev.launchwrapper.OptifineDevTweakerWrapper.injectIntoClassLoader(OptifineDevTweakerWrapper.java:39)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at net.minecraft.launchwrapper.Launch.launch(Launch.java:115)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at java.lang.reflect.Method.invoke(Method.java:498)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at net.minecraftforge.gradle.GradleStartCommon.launch(GradleStartCommon.java:97)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at GradleStart.main(GradleStart.java:25)
[13:23:39] [main/INFO] [STDOUT]: [optifine.OptiFineClassTransformer:dbg:242]: *** Can not find the OptiFine JAR in the classpath ***
[13:23:39] [main/INFO] [STDOUT]: [optifine.OptiFineClassTransformer:dbg:242]: *** OptiFine will not be loaded! ***
[13:23:39] [main/INFO] [STDOUT]: [ofdev.launchwrapper.OptifineDevTransformerWrapper:<init>:88]: Ignore the above, OptiFine should run anyway
[13:23:39] [main/INFO] [LaunchWrapper]: Calling tweak class optifine.OptiFineForgeTweaker
[13:23:39] [main/INFO] [STDOUT]: [optifine.OptiFineForgeTweaker:dbg:56]: OptiFineForgeTweaker: acceptOptions
[13:23:39] [main/INFO] [STDOUT]: [optifine.OptiFineForgeTweaker:dbg:56]: OptiFineForgeTweaker: injectIntoClassLoader
[13:23:39] [main/INFO] [STDOUT]: [optifine.OptiFineClassTransformer:dbg:242]: OptiFine ClassTransformer
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: java.lang.IllegalArgumentException: URI is not hierarchical
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at java.io.File.<init>(File.java:418)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at optifine.OptiFineClassTransformer.<init>(OptiFineClassTransformer.java:43)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at java.lang.Class.newInstance(Class.java:442)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at net.minecraft.launchwrapper.LaunchClassLoader.registerTransformer(LaunchClassLoader.java:88)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at optifine.OptiFineForgeTweaker.injectIntoClassLoader(OptiFineForgeTweaker.java:38)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at net.minecraft.launchwrapper.Launch.launch(Launch.java:115)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at java.lang.reflect.Method.invoke(Method.java:498)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at net.minecraftforge.gradle.GradleStartCommon.launch(GradleStartCommon.java:97)
[13:23:39] [main/INFO] [STDERR]: [optifine.OptiFineClassTransformer:<init>:55]: 	at GradleStart.main(GradleStart.java:25)
[13:23:39] [main/INFO] [STDOUT]: [optifine.OptiFineClassTransformer:dbg:242]: *** Can not find the OptiFine JAR in the classpath ***
[13:23:39] [main/INFO] [STDOUT]: [optifine.OptiFineClassTransformer:dbg:242]: *** OptiFine will not be loaded! ***
```

`LaunchClassLoader` will [modify CodeSources](https://github.com/Mojang/LegacyLauncher/blob/master/src/main/java/net/minecraft/launchwrapper/LaunchClassLoader.java#L175) of all classes if they are not in `transformerExceptions`.  
In other words, it will return different results of `this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI()` for different class loaders.  
For `sun.misc.Launcher$AppClassLoader`, it will return
```
file:/C:/optifine/OptiFine.jar
```
But for `net.minecraft.launchwrapper.LaunchClassLoader`, it will retrun
```
file:/C:/optifine/OptiFine.jar!/optifine/OptiFineClassTransformer.class
```
So it is neccessary to add `optifine.` into transfomer excxceptions.