### PR TITLE
Do not transform unnecessary classes

### DIFF
--- a/src/main/java/ofdev/launchwrapper/OptifineDevTransformerWrapper.java
+++ b/src/main/java/ofdev/launchwrapper/OptifineDevTransformerWrapper.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 // this is needed only in dev environment to get deobfuscated version of OptiFine running
 public class OptifineDevTransformerWrapper implements IClassTransformer {
@@ -79,6 +80,12 @@ public class OptifineDevTransformerWrapper implements IClassTransformer {
         }
 
         try {
+            boolean isOptifineClass = Stream.of("optifine.", "net.minecraft.", "net.minecraftforge.", "net.optifine.").anyMatch(name::startsWith)
+                    || !name.contains(".");
+            if (!isOptifineClass) {
+                return basicClass;
+            }
+
             String classJvmName = name.replace(".", "/");
 
             String notchName = remapper.notchFromMcp(classJvmName);
@@ -89,6 +96,7 @@ public class OptifineDevTransformerWrapper implements IClassTransformer {
             byte[] ofTransformedCode = getOptifineTransformedBytecode(name, basicClass, notchName, vanillaCode, isModified);
             // deobfuscate OptiFine transformed code to MCP names
             // this attempts to transform all the code but it shouldn't be an issue
+            // (cacpixel) it's a big issue because some MCP name can be conflicted with other NOTCH names
             ClassNode ofTransformedDeobfNode = toDeobfClassNode(ofTransformedCode);
             ClassNode vanillaDeobfNode = toDeobfClassNode(vanillaCode);
             ClassNode originalForgeNode = getClassNode(basicClass);


### PR DESCRIPTION
Do not transform unnecessary classes, because some MCP name can be conflicted with other NOTCH names.
![image](https://github.com/user-attachments/assets/f9436086-5598-4986-99c3-d20ffceb93e6)
In GuiTextField, notch name "x" and "y" conflict with the mcp name.
 
![image](https://github.com/user-attachments/assets/ac0d6de1-3552-40d6-a1a8-453f109d11b9)
it should be:
`return this.x < mouseX && mouseX < (this.x + this.width) && this.y < mouseY && mouseY < (this.y + this.height);`